### PR TITLE
Moved as.matrix outside of lapply.

### DIFF
--- a/R/interWeights.R
+++ b/R/interWeights.R
@@ -19,13 +19,16 @@ interWeights <- function(expDataBatch, trajCond, winSz, numPts){
     expDataBatch = expDataBatch[,-which(is.na(trajCond))]
     trajCond = trajCond[-which(is.na(trajCond))]
   }
+  
+  expDataBatchDense <- as.matrix(expDataBatch)
+  
   #generate equally-spaced points along the trajectory:
   trajValNewPts = seq(from=min(trajCond), to=max(trajCond), length.out = numPts) #length - numPts
   ValNewPts = do.call('cbind',lapply(trajValNewPts, function(trajPt){
     dist2Others = trajCond - trajPt #length - samples number
     weightedData = exp(-(dist2Others^2)/(winSz^2))
     weightedData = weightedData/sum(weightedData)
-    return(as.matrix(expDataBatch) %*% weightedData)
+    return(expDataBatchDense %*% weightedData)
   }))
   #sapply on the traj - for each real data point, find the closest interpolated point:
   a = 1

--- a/R/interWeights.R
+++ b/R/interWeights.R
@@ -38,12 +38,13 @@ interWeights <- function(expDataBatch, trajCond, winSz, numPts){
     return(abs(expDataBatch[rowInd,] - ValNewPts[rowInd,closestInt]))
   }))
 
+  errPerGeneDense <- as.matrix(errPerGene)
   #interpolate the error at each interpolated point:
   errInterpolated = do.call('cbind',lapply(trajValNewPts, function(trajPt){
     dist2Others = trajCond - trajPt #length - samples number
     weightedData = exp(-(dist2Others^2)/(winSz^2))
     weightedData = weightedData/sum(weightedData)
-    return(as.matrix(errPerGene) %*% weightedData)
+    return(errPerGeneDense %*% weightedData)
   }))
   rownames(errInterpolated) = rownames(ValNewPts)
 


### PR DESCRIPTION
I found that the interWeights function was taking a very long time to run on my dataset. Looking at the code, I think it's because it's converting the sparse counts matrix into a dense matrix within each iteration of the lapply function. I've moved it outside so this is only carried out once. It's working much faster now. 